### PR TITLE
ダウンロードURLの項目名がドキュメントどおりに取得できないので、WSDLに合わせて修正

### DIFF
--- a/docs/ja/api_reference/data/ReportDefinition/ReportDefinition.md
+++ b/docs/ja/api_reference/data/ReportDefinition/ReportDefinition.md
@@ -64,7 +64,7 @@ ReportDefinitionオブジェクトは、レポート定義を表します。
   <td>Ignore</td>
  </tr>
   <tr>
-  <td>reportDownloadURL</td>
+  <td>reportDownloadU</td>
   <td>xsd:string</td>
   <td>レポートのダウンロードURLです。<br>statusがCOMPLETEDの場合に値が設定されます。</td>
   <td>yes</td>

--- a/docs/ja/api_reference/data/ReportDefinition/ReportDefinition.md
+++ b/docs/ja/api_reference/data/ReportDefinition/ReportDefinition.md
@@ -64,7 +64,7 @@ ReportDefinitionオブジェクトは、レポート定義を表します。
   <td>Ignore</td>
  </tr>
   <tr>
-  <td>reportDownloadU</td>
+  <td>reportDownloadUrl</td>
   <td>xsd:string</td>
   <td>レポートのダウンロードURLです。<br>statusがCOMPLETEDの場合に値が設定されます。</td>
   <td>yes</td>


### PR DESCRIPTION
Although the document says it is "URL", we cannot get url for download from "URL."
https://github.com/yahoojp-marketing/ydn-api-documents/blob/master/docs/ja/api_reference/data/ReportDefinition/ReportDefinition.md

WSDL says it's "Url."
https://github.com/yahoojp-marketing/ydn-api-documents/blob/master/wsdl/ReportDefinitionService.wsdl#L153

